### PR TITLE
Support for quantitative evaluation of deconvolutions

### DIFF
--- a/examples/deconv_comparison.jl
+++ b/examples/deconv_comparison.jl
@@ -1,0 +1,101 @@
+# here we compare various deconvolution options in terms of image quality
+using IndexFunArrays, LinearAlgebra, Random, Noise, TestImages, FourierTools
+using DeconvOptim, FFTW, Optim, LineSearches
+using View5D, Plots
+
+obj = 100f0 .* Float32.(testimage("resolution_test_512"))
+# simulate a simple PSF
+sz = size(obj); 
+R_max = sz[1] ./ 12.0;
+psf = generate_psf(sz, R_max);
+
+# simulate a perfect image
+conv_img = DeconvOptim.conv(obj, psf);
+
+# set a fixed point for the measured data quality
+max_photons = 1000
+
+Random.seed!(42)
+measured = poisson(conv_img, max_photons);
+
+opt_options = nothing
+
+iterations = 100
+function get_data(summary)
+    return (summary["best_ncc_img"], summary["best_nvar_img"])
+end
+function show_ncc!(summary, title="")
+        nccs = summary["nccs"]
+        plt = plot!(nccs, label=title*" NCC")
+        col = plt[1][end].plotattributes[:markercolor]
+        vline!([summary["best_ncc_idx"]], line=:dash, color=col, label=title*"_best NCC")
+end
+
+function show_nvar!(summary, title="")
+    nvars = summary["nvars"]
+    nvars_norm = nvars ./ nvars[1]
+    plt = plot!(nvars_norm, label=title*" NVAR")
+    col = plt[1][end].plotattributes[:markercolor]
+    vline!([summary["best_nvar_idx"]], line=:dash, color=col, label=title*"_best NVAR")
+end
+
+function show_loss!(summary, addCurves="", lowest_loss=minimum(summary["losses"]))
+        losses = summary["losses"]
+        log_losses = log.(losses .- lowest_loss .+ 1)
+        rel_losses = log_losses # .- maximum(log_losses)
+        plot!(rel_losses[1:end-1], label=addCurves)
+        xlabel!("iteration")
+        ylabel!("log loss")
+end
+
+opt_options, get_noreg = options_trace_deconv(obj, iterations, Non_negative());
+
+res_noreg = deconvolution(measured, psf;
+        regularizer=nothing, iterations=iterations, mapping=Non_negative(),
+        opt_options=opt_options, debug_f=nothing)
+noreg_summary = get_noreg()
+
+opt_grad, get_grad = options_trace_deconv(obj, iterations, Non_negative(), );
+res_grad = deconvolution(measured, psf;
+        regularizer=nothing, iterations=iterations, mapping=Non_negative(),
+        opt=GradientDescent(), opt_options=opt_grad, debug_f=nothing)
+grad_summary = get_grad()
+        
+opt_gr, get_gr = options_trace_deconv(obj, iterations, Non_negative());
+
+res_gr = deconvolution(measured, psf;
+        regularizer=DeconvOptim.GR(), λ=1e-3, iterations=iterations,
+        mapping=Non_negative(), opt_options=opt_gr, debug_f=nothing)
+gr_summary = get_gr()
+
+opt_tv, get_tv = options_trace_deconv(obj, iterations, Non_negative())
+
+res_tv = deconvolution(measured, psf;
+        regularizer=DeconvOptim.TV(), λ=1e-3, iterations=iterations,
+        mapping=Non_negative(), opt_options=opt_tv, debug_f=nothing)
+tv_summary = get_tv()
+
+plot()
+title!("Regularization")
+do_display=false
+show_ncc!(noreg_summary, "NoReg")
+show_nvar!(noreg_summary, "NoReg")
+show_ncc!(gr_summary, "GR")
+show_nvar!(gr_summary, "GR")
+show_ncc!(tv_summary, "TV")
+show_nvar!(tv_summary, "TV")
+
+plot()
+title!("Optimization")
+show_loss!(noreg_summary, "LBFGS", minimum(noreg_summary["losses"]))
+show_loss!(grad_summary, "SteepestDecent", minimum(noreg_summary["losses"]))
+show_loss!(tv_summary, "TV", minimum(noreg_summary["losses"]))
+show_loss!(gr_summary, "GR", minimum(noreg_summary["losses"]))
+
+best_ncc_img, best_nvar_img = get_data(tv_summary)
+@vt obj
+@vt measured
+@vt best_ncc_img
+@vt best_nvar_img
+@vt res_noreg
+

--- a/src/analysis_tools.jl
+++ b/src/analysis_tools.jl
@@ -1,3 +1,5 @@
+export options_trace_deconv
+
 """
     relative_energy_regain(ground_truth, rec)
 
@@ -86,4 +88,132 @@ function normalized_cross_correlation(ground_truth, measured)
 
     ncc = crosscor(ground_truth, measured, [0], demean=true)[begin]
     return ncc
+end
+
+"""
+    normalized_variance(a, b)
+
+Calculates the mean variance between two array, but normalizing arra a to the same mean as array b.
+"""
+function normalized_variance(a, b)
+    factor = sum(b)/sum(a)
+    sum(abs2.(a.*factor .-b))./prod(size(a))
+    # sum(abs2.(a./sum(a).*sum(b) .-b))
+end
+
+
+"""
+    options_trace_deconv(ground_truth, iterations, mapping, every=1)
+
+    A useful routine to simplify performance checks of deconvolution on simulated data.
+    Returns an Options structure to be used with the deconvolution routine as an argument to `opt_options` and 
+    a function that returns the summary dictionary with all the performance metrics calculated.
+    This can then be plotted or visualized.
+    The summary dictionary has the following content:
+
+    "best_nvar"     => the lowest normalized variance compared to the `ground_truth` that was achieved.
+    "best_nvar_img" => the reconstruction result corresponding to this lowest normalized variance
+    "best_nvar_idx" => the corresponding index where this was achieved. `(best_nvar_idx-1)*every+1` approximated the iteration number.
+    "best_ncc"      => the highest normalized crosscorrelation compared to the `ground_truth` that was achieved.
+    "best_ncc_img"  => the reconstruction result corresponding to this highest normalized crosscorrelation
+    "losses"        => the vector of losses evaluated at each of `every` iterations.
+    "nccs"          => the vector of normalized cross correlations calculated at each of `every` iterations.
+    "best_ncc_idx"  => the corresponding index where this was achieved. `(best_ncc_idx-1)*every+1` approximated the iteration number.
+    "nvars"         => the vector of normalized variances calculated at each of `every` iterations.
+
+    For an example of how to plot the results, see the file `` in the `examples` folder.
+# Arguments
+- `ground_truth`: The underlying ground truth data. Note that this scaling is unimportant due to the normalized norms used for comparison, whereas the relative offset matters. 
+- `iterations`: The maximal number of iterations to performance. If covergence is reached, the result may have less iterations
+- `mapping`: If mappings such as the positivity contraints (e.g. `NonNegative()`) are used in the deconvolution routing, they also need to be provided here. Otherwises select `nothing`.
+- `every`: This option allows to select every how many iterations the evaluation is performed. Note that the results will not keep track of this iteration number. 
+
+# Example
+```julia-repl
+julia> using DeconvOptim, TestImages, Noise, Plots;
+
+julia> obj = Float32.(testimage("resolution_test_512"));
+
+julia> psf = Float32.(generate_psf(size(obj), 30));
+
+julia> img_b = conv(obj, psf);
+
+julia> img_n = poisson(img_b, 300);
+
+julia> iterations = 100;
+
+julia> opt_noreg, show_noreg = options_trace_deconv(obj, iterations, Non_negative());
+
+julia> res_noreg, o = deconvolution(img_n, psf, regularizer = nothing, opt_options=opt_noreg);
+
+julia> opt_GR, show_GR = options_trace_deconv(obj, iterations, Non_negative());
+
+julia> res_GR, o = deconvolution(img_n, psf, λ=1e-2, regularizer=DeconvOptim.GR(), opt_options=opt_GR);
+
+julia> opt_TV, show_TV = options_trace_deconv(obj, iterations, Non_negative());
+
+julia> res_TV, o = deconvolution(img_n, psf, λ=1e-3, regularizer=DeconvOptim.TV(), opt_options=opt_TV);
+
+julia> plot()
+
+julia> show_noreg(false,"NoReg")
+
+julia> show_GR(false,"GR")
+
+julia> show_TV(false,"TV")
+
+julia> using View5D
+
+julia> @vt (ground_truth, best_ncc_img, best_nvar_img) = show_noreg(true)
+```
+"""
+function options_trace_deconv(ground_truth, iterations, mapping, every=1)
+    summary = Dict(
+        "losses" => [],
+        "best_ncc" => -Inf,
+        "best_ncc_idx" => 0,
+        "best_ncc_img" => [],
+        "nccs" => [],
+        "best_nvar" => Inf,
+        "best_nvar_idx" => 0,
+        "best_nvar_img" => [],
+        "nvars" => [] )
+    idx = 1
+    cb = tr -> begin
+            if tr[end].iteration == 1
+                    summary["losses"] = [];summary["best_ncc"] = -Inf;summary["best_ncc_idx"] = 0;summary["best_ncc_img"] = [];summary["nccs"] = []
+                    summary["best_nvar"] = Inf;summary["best_nvar_idx"] = 0;summary["best_nvar_img"] = [];summary["nvars"] = []
+                    idx = 1
+            end
+            loss = tr[end].value
+            push!(summary["losses"], loss)
+            img = mapping[1](tr[end].metadata["x"]) # currently best image
+            # @vr img
+            ncc = DeconvOptim.normalized_cross_correlation(ground_truth, img)
+            push!(summary["nccs"], ncc)
+            summary["best_ncc"], summary["best_ncc_img"], summary["best_ncc_idx"] = let
+                    if ncc > summary["best_ncc"]
+                            (ncc, img, idx) 
+                    else
+                            (summary["best_ncc"], summary["best_ncc_img"], summary["best_ncc_idx"])
+                    end
+            end
+            nvar = normalized_variance(img, ground_truth)
+            push!(summary["nvars"], nvar)
+            summary["best_nvar"], summary["best_nvar_img"], summary["best_nvar_idx"] = let 
+                    if nvar < summary["best_nvar"]
+                            (nvar, img, idx)
+                    else
+                            (summary["best_nvar"], summary["best_nvar_img"], summary["best_nvar_idx"])
+                    end
+            end
+            idx += 1
+            false
+            end
+    function get_summary()
+        return summary
+    end
+
+    opt_options = Optim.Options(callback = cb, iterations=iterations, show_every=every, store_trace=true, extended_trace=true)
+    return (opt_options, get_summary)
 end

--- a/src/analysis_tools.jl
+++ b/src/analysis_tools.jl
@@ -187,7 +187,11 @@ function options_trace_deconv(ground_truth, iterations, mapping, every=1)
             end
             loss = tr[end].value
             push!(summary["losses"], loss)
-            img = mapping[1](tr[end].metadata["x"]) # currently best image
+            img = (mapping === nothing) ? tr[end].metadata["x"] : mapping[1](tr[end].metadata["x"]) # current image
+            # the line below is needed, since in the iterations, the measurement is rescaled to a mean of one.
+            # see deconvolution.jl.  This rescaling is only an estimate and does not affect the norms.
+            img *= mean(ground_truth)
+
             # @vr img
             ncc = DeconvOptim.normalized_cross_correlation(ground_truth, img)
             push!(summary["nccs"], ncc)

--- a/src/deconvolution.jl
+++ b/src/deconvolution.jl
@@ -18,8 +18,9 @@ regularizers and mappings.
 - `background=0`: A float indicating a background intensity level.
 - `mapping=Non_negative()`: Applies a mapping of the optimizer weight. Default is a 
               parabola which achieves a non-negativity constraint.
-- `iterations=20`: Specifies a number of iterations after the optimization.
-    definitely should stop.
+- `iterations=nothing`: Specifies a number of iterations after the optimization.
+    definitely should stop. By default 20 iterations will be selected by generic_invert.jl, 
+    if `nothing` is provided.
 - `conv_dims`: A tuple indicating over which dimensions the convolution should happen.
                per default `conv_dims=1:ndims(psf)`
 - `plan_fft=true`: Boolean whether plan_fft is used. Gives a slight speed improvement.
@@ -46,7 +47,7 @@ julia> img_b = conv(img, psf);
 
 julia> img_n = poisson(img_b, 300);
 
-julia> @time res, o = deconvolution(img_n, psf);
+julia> res, o = deconvolution(img_n, psf);
 ```
 """
 function deconvolution(measured::AbstractArray{T, N}, psf;
@@ -55,7 +56,7 @@ function deconvolution(measured::AbstractArray{T, N}, psf;
         λ=T(0.05),
         background=zero(T),
         mapping=Non_negative(),
-        iterations=20,
+        iterations=nothing,
         conv_dims = ntuple(+, ndims(psf)), 
         padding=0.00,
         opt_options=nothing,

--- a/src/generic_invert.jl
+++ b/src/generic_invert.jl
@@ -103,7 +103,7 @@ function invert(measured, rec0, forward;
     end
 
     if isa(opt_package, Type{Opt_Optim}) 
-        opt_options = Optim.Options(iterations=iterations)
+        # opt_options = Optim.Options(iterations=iterations)
         
         # do the optimization with LBGFS
         res = Optim.optimize(Optim.only_fg!(fg!), rec0, opt, opt_options)

--- a/test/analysis_tools.jl
+++ b/test/analysis_tools.jl
@@ -15,4 +15,18 @@
         @test DeconvOptim.normalized_cross_correlation(x, x) == 1.0f0
     end
 
+    @testset "Normalized Cross Correlation" begin
+        sz = (10,10)
+        x = rand(sz...)
+        psf = rand(10,10)
+        psf /= sum(psf)
+        y = conv(x,psf)
+        # test whether starting with the ground truth really yield the perfect reconstruction after 0 iterations
+        opt_options, get_summary = options_trace_deconv(x, 0, nothing)
+        res = deconvolution(y,psf; initial=x, mapping=nothing, padding=0.0, opt_options=opt_options)
+        summary = get_summary()
+        @test summary["nccs"][1] > 0.999
+        @test summary["nvars"][1] < 0.001
+        @test (summary["best_nvar_img"] ≈ x)
+    end
 end


### PR DESCRIPTION
In the analysis_tools.jl support for quantitative evaluation of deconvolutions was added via returning an option structure to be provided to the `deconvolution` routine. This includes a callback function that saves summary data including two norms for comparing with the ground truth data and it also stores then best result images for each of these norms. 
An example is provided on how to use this framework to provide plots of these norms as well as the loss.